### PR TITLE
Fix finance page toggles

### DIFF
--- a/spending.html
+++ b/spending.html
@@ -1,3 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Spending &amp; Finances</title>
+<style>
+body { font-family: 'Segoe UI', Tahoma, sans-serif; margin: 0; padding: 0; }
+header { background: #fff; color: #ff69b4; padding: 1rem; text-align: center; border-bottom: 1px solid #ddd; }
+nav { display: flex; gap: 1rem; padding: 0.5rem; background: #f4f4f4; }
+nav a { color: #333; text-decoration: none; }
+section { padding: 1rem; border-bottom: 10px solid pink; }
+.toggle { cursor: pointer; background: #f4f4f4; padding: 0.5rem; border-radius: 4px; margin: 1rem 0; text-align: center; }
+.add-toggle { background: #eee; font-size: 0.45rem; }
+.section-header { font-size: 1.2rem; font-weight: bold; background: #cfe2ff; }
+.subtoggle { font-size: 0.9rem; margin-top: 0.5rem; }
+.form-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(200px, 1fr)); gap: 0.5rem; align-items: center; }
+.form-grid label { display: flex; flex-direction: column; font-size: 0.9rem; }
+.form-grid input, .form-grid select { width: 100%; font-size: 1rem; padding: 0.4rem; }
+.task-table { width: 100%; border-collapse: collapse; }
+.task-table th, .task-table td { border: 1px solid #ccc; padding: 0.25rem; text-align: left; }
+.hidden { display: none !important; }
+</style>
+</head>
 <body>
 <header><h1>Spending &amp; Finances</h1></header>
 <nav>


### PR DESCRIPTION
## Summary
- Add missing HTML head and styling to finance page
- Define `.hidden` class to enable section toggling

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_688f8735e770832f85a0811f8cce5fbf