### PR TITLE
Fix duplicate budget modal

### DIFF
--- a/finance.html
+++ b/finance.html
@@ -96,7 +96,6 @@ th,td{border:1px solid #ccc;padding:0.25rem 0.5rem;}
       <tbody></tbody>
     </table>
   </div>
-  <div id="budget-modal" style="display:none;position:fixed;top:10%;left:10%;right:10%;background:#fff;border:1px solid #ccc;padding:1rem;max-height:80%;overflow:auto;"></div>
   <h3>Autofill Rules</h3>
   <form id="rule-form">
     <input type="text" id="rule-desc" placeholder="Description contains" required>


### PR DESCRIPTION
## Summary
- Remove extra `budget-modal` element so only one modal remains on the finance page

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_688f8c8ea684832fb2511d4cd08b08ce