### PR TITLE
Fix duplicate budget modal and initialize tab handlers after DOM load

### DIFF
--- a/finance.html
+++ b/finance.html
@@ -96,7 +96,6 @@ th,td{border:1px solid #ccc;padding:0.25rem 0.5rem;}
       <tbody></tbody>
     </table>
   </div>
-  <div id="budget-modal" style="display:none;position:fixed;top:10%;left:10%;right:10%;background:#fff;border:1px solid #ccc;padding:1rem;max-height:80%;overflow:auto;"></div>
   <h3>Autofill Rules</h3>
   <form id="rule-form">
     <input type="text" id="rule-desc" placeholder="Description contains" required>
@@ -1112,10 +1111,12 @@ function parseFile(file, accountType, accountName){
   if(ext === 'csv') reader.readAsText(file); else reader.readAsBinaryString(file);
 }
 
-loadFinance();
-document.getElementById('tab-upload').addEventListener('click', () => showTab('upload'));
-document.getElementById('tab-code').addEventListener('click', () => showTab('code'));
-document.getElementById('tab-budgets').addEventListener('click', () => showTab('budgets'));
+window.addEventListener('DOMContentLoaded', () => {
+  loadFinance();
+  document.getElementById('tab-upload').addEventListener('click', () => showTab('upload'));
+  document.getElementById('tab-code').addEventListener('click', () => showTab('code'));
+  document.getElementById('tab-budgets').addEventListener('click', () => showTab('budgets'));
+});
 document.getElementById('add-account').addEventListener('click', () => {
   const name = document.getElementById('new-account').value.trim();
   if(!name || financeData.accounts.includes(name)) return;


### PR DESCRIPTION
## Summary
- Remove extra `budget-modal` element so only one modal remains on the finance page
- Initialize Upload/Code/Budgets tab handlers after DOM ready so sections switch correctly

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_688f8c8ea684832fb2511d4cd08b08ce