### PR TITLE
feat: restore budget category management

### DIFF
--- a/finance.html
+++ b/finance.html
@@ -120,7 +120,7 @@ th,td{border:1px solid #ccc;padding:0.25rem 0.5rem;}
   </label>
   <table id="budget-table">
     <thead>
-      <tr><th>Name</th><th>Amount</th><th>Recurring</th><th>Date</th><th></th><th>Archived</th></tr>
+      <tr><th>Name</th><th>Description</th><th>Amount</th><th>Recurring</th><th>Date</th><th></th><th>Archived</th></tr>
     </thead>
     <tbody></tbody>
   </table>
@@ -167,7 +167,7 @@ th,td{border:1px solid #ccc;padding:0.25rem 0.5rem;}
 <script src="node_modules/papaparse/papaparse.min.js"></script>
 <script src="node_modules/xlsx/dist/xlsx.full.min.js"></script>
 <script>
-let financeData = { accounts: [], transactions: [], nextTransactionId: 1, budgetCategories: [], budgets: [], nextBudgetId: 1, rules: [], budgetPeriods: [] };
+let financeData = { accounts: [], transactions: [], nextTransactionId: 1, budgetCategories: [], budgets: [], nextBudgetId: 1, rules: [], budgetPeriods: [], categoryStarts: {} };
 let lastTxCheckbox = null;
 const isMobile = /Mobi|Android/i.test(navigator.userAgent);
 
@@ -187,6 +187,7 @@ async function loadFinance(){
   if(!financeData.budgetCategories.includes('Other \u2013 Not Budgeted')){
     financeData.budgetCategories.push('Other \u2013 Not Budgeted');
   }
+  financeData.categoryStarts = financeData.categoryStarts || {};
   financeData.budgets = (financeData.budgets || []).map(b=>{
     if(!b.versions){
       const start = b.date || new Date().toISOString().slice(0,10);
@@ -194,6 +195,7 @@ async function loadFinance(){
       b.versions = [{ amount: b.amount || 0, start, end, interval: b.recurring ? 1 : 0, mode: 'within' }];
     }
     b.extras = b.extras || [];
+    b.desc = b.desc || '';
     normalizeVersions(b);
     return b;
   });
@@ -498,7 +500,7 @@ function renderTransactions(){
       if(type && name && !financeData.budgets.some(b=>b.type===type && b.name===name)){
         const todayStr=new Date().toISOString().slice(0,10);
         const far=new Date(new Date(todayStr).setFullYear(new Date(todayStr).getFullYear()+100)).toISOString().slice(0,10);
-        financeData.budgets.push({id:financeData.nextBudgetId++, type, name, archived:false, versions:[{amount:0,start:todayStr,end:far,interval:1,mode:'within'}], extras:[]});
+        financeData.budgets.push({id:financeData.nextBudgetId++, type, name, archived:false, versions:[{amount:0,start:todayStr,end:far,interval:1,mode:'within'}], extras:[], desc:''});
         populateST();
         saveFinance();
         renderBudgets();
@@ -569,6 +571,7 @@ function renderBudgets(){
       delCatBtn.disabled = true;
     }
     tr.appendChild(document.createElement('td')).textContent = cat;
+    tr.appendChild(document.createElement('td')).textContent = '';
     tr.appendChild(document.createElement('td')).textContent = g.amount;
     tr.appendChild(document.createElement('td'));
     tr.appendChild(document.createElement('td'));
@@ -578,7 +581,7 @@ function renderBudgets(){
     g.items.forEach(sub=>{
       const tr2 = document.createElement('tr');
       const v=currentBudgetVersion(sub) || {amount:'',interval:1,mode:'within',start:'',end:''};
-      tr2.innerHTML = `<td style="padding-left:20px;">${sub.name}</td><td>${v.amount}</td><td>${v.interval>1?`Every ${v.interval} (${v.mode})`:'Monthly'}</td><td>${v.start}</td>`;
+      tr2.innerHTML = `<td style="padding-left:20px;">${sub.name}</td><td>${sub.desc||''}</td><td>${v.amount}</td><td>${v.interval>1?`Every ${v.interval} (${v.mode})`:'Monthly'}</td><td>${v.start}</td>`;
       const editSubBtn=document.createElement('button');
       editSubBtn.textContent='Edit';
       editSubBtn.addEventListener('click',()=>openBudgetModal(sub));
@@ -710,20 +713,23 @@ function amountForMonth(sub, month){
   return baseAmountForMonth(sub, month) + extraForMonth(sub, month);
 }
 
-function openBudgetModal(sub, editIndex=-1){
+function openBudgetModal(sub, editIndex=-1, isNew=false){
+  sub.versions = sub.versions || [];
   normalizeVersions(sub);
   const modal=document.getElementById('budget-modal');
   if(!modal) return;
   const todayStr=new Date().toISOString().slice(0,10);
   const far=new Date(new Date(todayStr).setFullYear(new Date(todayStr).getFullYear()+100)).toISOString().slice(0,10);
-  const curr=currentBudgetVersion(sub);
-  const v=editIndex>=0 ? sub.versions[editIndex] : (curr || {amount:0,start:todayStr,end:far,interval:1,mode:'within'});
-  const allStart=sub.versions.reduce((m,x)=>parseDate(x.start)<m?parseDate(x.start):m,parseDate(sub.versions[0].start));
-  const allEnd=sub.versions.reduce((m,x)=>parseDate(x.end)>m?parseDate(x.end):m,parseDate(sub.versions[0].end));
+  const curr=sub.versions.length?currentBudgetVersion(sub):null;
+  const defaultVer={amount:0,start:todayStr,end:far,interval:1,mode:'within'};
+  const v=editIndex>=0 && sub.versions[editIndex]? sub.versions[editIndex] : (curr || defaultVer);
+  const allStart=sub.versions.length? sub.versions.reduce((m,x)=>parseDate(x.start)<m?parseDate(x.start):m,parseDate(sub.versions[0].start)) : parseDate(v.start);
+  const allEnd=sub.versions.length? sub.versions.reduce((m,x)=>parseDate(x.end)>m?parseDate(x.end):m,parseDate(sub.versions[0].end)) : parseDate(v.end);
   const monthOpts=monthsBetween(allStart,allEnd);
   modal.innerHTML=`<form id="budget-edit-form">
     <label>Category <select id="edit-type"></select></label>
-    <label>Name <input type="text" value="${sub.name}" disabled></label>
+    <label>Name <input type="text" id="edit-name" value="${sub.name||''}" ${isNew?'':'disabled'}></label>
+    <label>Description <textarea id="edit-desc">${sub.desc||''}</textarea></label>
     <label>Amount <input type="number" id="edit-amount" value="${v.amount}"></label>
     <label>Start <input type="date" id="edit-start" value="${v.start}"></label>
     <label>End <input type="date" id="edit-end" value="${v.end}"></label>
@@ -731,7 +737,7 @@ function openBudgetModal(sub, editIndex=-1){
     <label>Mode <select id="edit-mode"><option value="within">Within Month</option><option value="throughout">Throughout</option></select></label>
     <button type="submit">Save</button>
     <button type="button" id="close-budget-modal">Close</button>
-    ${editIndex>=0 ? '<button type="button" id="cancel-edit">Cancel</button>' : ''}
+    ${(editIndex>=0 && !isNew) ? '<button type="button" id="cancel-edit">Cancel</button>' : ''}
   </form>
   <h4>History</h4>
   <table><thead><tr><th>Ver</th><th>Start</th><th>End</th><th>Amount</th><th>Interval</th><th>Mode</th><th></th></tr></thead><tbody></tbody></table>
@@ -744,27 +750,27 @@ function openBudgetModal(sub, editIndex=-1){
   <table id="extra-table"><thead><tr><th>Month</th><th>Amount</th><th></th></tr></thead><tbody></tbody></table>`;
   const typeSel=modal.querySelector('#edit-type');
   financeData.budgetCategories.forEach(cat=>{ const o=document.createElement('option'); o.value=cat; o.textContent=cat; typeSel.appendChild(o); });
-  typeSel.value=sub.type;
+  typeSel.value=sub.type||'';
   const modeSel=modal.querySelector('#edit-mode'); modeSel.value=v.mode||'within';
   if(editIndex===-1){
     if(v.start===todayStr) modal.querySelector('#edit-start').insertAdjacentHTML('afterend','<small>(default today)</small>');
     if(v.end===far) modal.querySelector('#edit-end').insertAdjacentHTML('afterend','<small>(default 100y)</small>');
   }
-  const tbody=modal.querySelector('tbody');
-  sub.versions.slice().sort((a,b)=>parseDate(b.start)-parseDate(a.start)).forEach(ver=>{
+  const histTbody=modal.querySelector('table tbody');
+  (sub.versions||[]).slice().sort((a,b)=>parseDate(b.start)-parseDate(a.start)).forEach(ver=>{
     const idx=sub.versions.indexOf(ver);
     const tr=document.createElement('tr');
     tr.innerHTML=`<td>${ver.version||idx+1}</td><td>${ver.start}</td><td>${ver.end}</td><td>${ver.amount}</td><td>${ver.interval||1}</td><td>${ver.mode||'within'}</td><td><button class="edit-ver" data-idx="${idx}">Edit</button><button class="del-ver" data-idx="${idx}">Delete</button></td>`;
     if(ver===curr) tr.style.background='lightgreen';
-    tbody.appendChild(tr);
+    histTbody.appendChild(tr);
   });
-  tbody.querySelectorAll('.edit-ver').forEach(btn=>{
+  histTbody.querySelectorAll('.edit-ver').forEach(btn=>{
     btn.addEventListener('click',()=>{
       const idx=parseInt(btn.dataset.idx);
       openBudgetModal(sub, idx);
     });
   });
-  tbody.querySelectorAll('.del-ver').forEach(btn=>{
+  histTbody.querySelectorAll('.del-ver').forEach(btn=>{
     btn.addEventListener('click',()=>{
       const idx=parseInt(btn.dataset.idx);
       if(confirm('Delete this version?')){
@@ -822,12 +828,14 @@ function openBudgetModal(sub, editIndex=-1){
   });
   modal.style.display='block';
   modal.querySelector('#close-budget-modal').addEventListener('click',()=>{ modal.style.display='none'; });
-  if(editIndex>=0){
+  if(editIndex>=0 && !isNew){
     modal.querySelector('#cancel-edit').addEventListener('click',()=>openBudgetModal(sub));
   }
   modal.querySelector('#budget-edit-form').addEventListener('submit',e=>{
     e.preventDefault();
     const newType=typeSel.value;
+    const name=modal.querySelector('#edit-name').value.trim();
+    const desc=modal.querySelector('#edit-desc').value.trim();
     const amount=parseFloat(modal.querySelector('#edit-amount').value);
     const start=modal.querySelector('#edit-start').value||todayStr;
     const end=modal.querySelector('#edit-end').value||far;
@@ -837,21 +845,35 @@ function openBudgetModal(sub, editIndex=-1){
     }
     const interval=parseInt(modal.querySelector('#edit-interval').value)||1;
     const mode=modal.querySelector('#edit-mode').value;
-    if(editIndex>=0){
-      sub.versions[editIndex]={amount,start,end,interval,mode};
+    if(isNew){
+      if(!newType || !name) return;
+      sub.type=newType;
+      sub.name=name;
+      sub.desc=desc;
+      sub.archived=false;
+      sub.versions=[{amount,start,end,interval,mode}];
+      sub.extras=[];
+      financeData.budgets.push(sub);
+      financeData.nextBudgetId++;
     } else {
-      sub.versions.push({amount,start,end,interval,mode});
+      const same=v.amount==amount && v.start==start && v.end==end && v.interval==interval && v.mode==mode;
+      if(editIndex>=0){
+        sub.versions[editIndex]={amount,start,end,interval,mode};
+      } else if(!same){
+        sub.versions.push({amount,start,end,interval,mode});
+      }
+      sub.desc=desc;
+      if(newType!==sub.type){
+        financeData.transactions.forEach(t=>{ if(t.type===sub.type && t.subType===sub.name){ t.type=newType; } });
+        financeData.rules.forEach(r=>{ if(r.type===sub.type && r.subType===sub.name){ r.type=newType; } });
+        sub.type=newType;
+      }
     }
     normalizeVersions(sub);
     const currV=currentBudgetVersion(sub);
     if(currV){
       sub.amount=currV.amount;
       sub.date=currV.start;
-    }
-    if(newType!==sub.type){
-      financeData.transactions.forEach(t=>{ if(t.type===sub.type && t.subType===sub.name){ t.type=newType; } });
-      financeData.rules.forEach(r=>{ if(r.type===sub.type && r.subType===sub.name){ r.type=newType; } });
-      sub.type=newType;
     }
     modal.style.display='none';
     saveFinance();
@@ -869,27 +891,25 @@ function renderSettingsSections(){
       <h3>Budget Settings</h3>
       <form class="type-form">
         <input type="text" class="new-type-name" placeholder="New Category">
+        <input type="date" class="new-type-start">
         <button type="submit">Add Category</button>
       </form>
       <ul class="type-list"></ul>
       <form class="subtype-form">
         <select class="subtype-type"></select>
-        <input type="text" class="subtype-name" placeholder="Sub Type Name">
-        <input type="number" class="subtype-amount" placeholder="Amount">
-        <input type="date" class="subtype-start"><small class="start-note"></small>
-        <input type="date" class="subtype-end"><small class="end-note"></small>
-        <input type="number" class="subtype-interval" value="1" placeholder="Every N months">
-        <select class="subtype-mode"><option value="within">Within Month</option><option value="throughout">Throughout</option></select>
-        <button type="submit">Add Sub Type</button>
+        <button type="button" class="add-subtype-btn">Add Sub Type</button>
       </form>
       <div class="subtype-lists"></div>`;
     const typeForm = container.querySelector('.type-form');
     typeForm.addEventListener('submit', e=>{
       e.preventDefault();
       const name = container.querySelector('.new-type-name').value.trim();
+      const start = container.querySelector('.new-type-start').value || new Date().toISOString().slice(0,10);
       if(!name || financeData.budgetCategories.includes(name)) return;
       financeData.budgetCategories.push(name);
+      financeData.categoryStarts[name]=start;
       container.querySelector('.new-type-name').value='';
+      container.querySelector('.new-type-start').value='';
       saveFinance();
       updateTypeOptions();
       renderBudgets();
@@ -898,50 +918,23 @@ function renderSettingsSections(){
     });
     const subtypeForm = container.querySelector('.subtype-form');
     const typeSelect = container.querySelector('.subtype-type');
-    const startInput = container.querySelector('.subtype-start');
-    const endInput = container.querySelector('.subtype-end');
-    const startNote = container.querySelector('.start-note');
-    const endNote = container.querySelector('.end-note');
-    const todayStr = new Date().toISOString().slice(0,10);
-    startInput.value = todayStr;
-    startNote.textContent = '(default today)';
-    const defEnd = new Date(new Date(todayStr).setFullYear(new Date(todayStr).getFullYear()+100)).toISOString().slice(0,10);
-    endInput.value = defEnd;
-    endNote.textContent = '(default 100y)';
     function fillTypes(){
       typeSelect.innerHTML = '<option value="">Select type</option>';
       financeData.budgetCategories.forEach(t=>{ const o=document.createElement('option'); o.value=t; o.textContent=t; typeSelect.appendChild(o); });
     }
     fillTypes();
-    subtypeForm.addEventListener('submit', e=>{
-      e.preventDefault();
+    subtypeForm.querySelector('.add-subtype-btn').addEventListener('click',()=>{
       const type = typeSelect.value;
-      const name = container.querySelector('.subtype-name').value.trim();
-      const amt = parseFloat(container.querySelector('.subtype-amount').value);
-      const start = startInput.value || todayStr;
-      const end = endInput.value || defEnd;
-      const interval = parseInt(container.querySelector('.subtype-interval').value)||1;
-      const mode = container.querySelector('.subtype-mode').value;
-      if(!type || !name) return;
-      const nb={id:financeData.nextBudgetId++, type, name, archived:false, versions:[{amount:amt,start,end,interval,mode}], extras:[]};
-      financeData.budgets.push(nb);
-      normalizeVersions(nb);
-      container.querySelector('.subtype-name').value='';
-      container.querySelector('.subtype-amount').value='';
-      container.querySelector('.subtype-interval').value='1';
-      container.querySelector('.subtype-mode').value='within';
-      startInput.value=todayStr;
-      endInput.value=defEnd;
-      saveFinance();
-      renderBudgets();
-      renderOverview();
-      renderSettingsSections();
+      if(!type) return;
+      const nb={id:financeData.nextBudgetId, type, name:'', archived:false, versions:[], extras:[], desc:''};
+      openBudgetModal(nb, -1, true);
     });
 
     const typeList = container.querySelector('.type-list');
     financeData.budgetCategories.forEach(cat=>{
       const li=document.createElement('li');
-      li.textContent=cat;
+      const start=financeData.categoryStarts[cat]||'';
+      li.textContent=start?`${cat} (${start})`:cat;
       if(!cat.startsWith('Other')){
         const del=document.createElement('button');
         del.textContent='Delete';
@@ -951,6 +944,7 @@ function renderSettingsSections(){
             financeData.transactions.forEach(t=>{ if(t.type===cat){ t.type=''; t.subType=''; } });
             financeData.rules = financeData.rules.filter(r=>r.type!==cat);
             financeData.budgetCategories = financeData.budgetCategories.filter(c=>c!==cat);
+            delete financeData.categoryStarts[cat];
             saveFinance();
             renderBudgets();
             renderOverview();
@@ -974,7 +968,7 @@ function renderSettingsSections(){
       const ul=document.createElement('ul');
       subs.forEach(sub=>{
         const li=document.createElement('li');
-        li.textContent=sub.name;
+        li.textContent=sub.desc?`${sub.name} - ${sub.desc}`:sub.name;
         const edit=document.createElement('button'); edit.textContent='Edit';
         edit.addEventListener('click',()=>openBudgetModal(sub));
         const del=document.createElement('button'); del.textContent='Delete';


### PR DESCRIPTION
## Summary
- reintroduce budget settings to create categories and sub categories
- allow descriptions on sub budgets and show them in the budget table
- support creating new sub budgets through modal dialog with intervals and amounts

## Testing
- `npm test` (fails: Missing script: "test")

------
https://chatgpt.com/codex/tasks/task_e_688fb894b000832faa5d7a692db7d0db